### PR TITLE
Added support for GIT Tag.

### DIFF
--- a/NetRevisionTool/AssemblyInfoHelper.cs
+++ b/NetRevisionTool/AssemblyInfoHelper.cs
@@ -312,7 +312,7 @@ namespace NetRevisionTool
 			if (simpleAttributes && !revOnly)
 			{
 				string revisionId = rf.Resolve(revisionFormat);
-				truncVersion = Regex.Replace(revisionId, @"[^0-9.].*$", "");
+				truncVersion = Regex.Replace(revisionId, @"[^0-9.].*$", "").TrimEnd('.');
 				if (!truncVersion.Contains("."))
 					throw new ConsoleException("Revision ID cannot be truncated to dotted-numeric: " + revisionId, ExitCodes.NoNumericVersion);
 				Version version;

--- a/NetRevisionTool/Manual.txt
+++ b/NetRevisionTool/Manual.txt
@@ -61,6 +61,8 @@ The format defines how information about the commit or revision is formatted int
 {aname}, {amail}      Author’s name or e-mail address.
 {branch}              Currently checked-out branch.
 {branch:<sep>:<ref>}  Branch name, if not <ref>, separated by <sep>, otherwise empty.
+{gitTag}			  Print the current tag name. Usefull if you tag releases. Name a tag by version ex.: 1.1.1, will result in output : 1.1.1-20-gfaeeb36
+
 
 ♦TIME SCHEMES♣
 

--- a/NetRevisionTool/RevisionData.cs
+++ b/NetRevisionTool/RevisionData.cs
@@ -77,6 +77,12 @@ namespace NetRevisionTool
 		/// </summary>
 		public string Branch { get; set; }
 
+        /// <summary>
+        /// Gets or sets the result of a git describe. When using tag as a revision, specify name using this format in git : vN.N.N
+        /// Ex.: Tag name v1.1.1
+        /// </summary>
+        public string Tag { get; set; }
+
 		#endregion Revision data properties
 
 		#region Operations
@@ -93,6 +99,7 @@ namespace NetRevisionTool
 			if (AuthorName == null) AuthorName = "";
 			if (AuthorEMail == null) AuthorEMail = "";
 			if (Branch == null) Branch = "";
+            if (Tag == null) Tag = "";
 		}
 
 		/// <summary>
@@ -114,6 +121,7 @@ namespace NetRevisionTool
 			Program.ShowDebugMessage("  RepositoryUrl: " + RepositoryUrl);
 			Program.ShowDebugMessage("  RevisionNumber: " + RevisionNumber);
 			Program.ShowDebugMessage("  VcsProvider: " + VcsProvider);
+            Program.ShowDebugMessage("  Tag: " + Tag);
 		}
 
 		#endregion Operations

--- a/NetRevisionTool/RevisionFormat.cs
+++ b/NetRevisionTool/RevisionFormat.cs
@@ -80,7 +80,9 @@ namespace NetRevisionTool
 			format = format.Replace("{aname}", RevisionData.AuthorName);
 			format = format.Replace("{amail}", RevisionData.AuthorEMail);
 			format = format.Replace("{branch}", RevisionData.Branch);
-			format = Regex.Replace(format, @"\{branch:(.*?):(.+?)\}", m => RevisionData.Branch != m.Groups[2].Value ? m.Groups[1].Value + RevisionData.Branch : "");
+            format = format.Replace("{gitTag}", RevisionData.Tag);
+            
+            format = Regex.Replace(format, @"\{branch:(.*?):(.+?)\}", m => RevisionData.Branch != m.Groups[2].Value ? m.Groups[1].Value + RevisionData.Branch : "");
 
 			// Resolve time schemes
 			format = Regex.Replace(format, @"\{[AaBbCc]:.+?\}", FormatTimeScheme);
@@ -91,6 +93,7 @@ namespace NetRevisionTool
 			{
 				commitString = RevisionData.RevisionNumber.ToString();
 			}
+
 			format = format.Replace("{commit}", commitString);
 			format = Regex.Replace(format, @"\{commit:([0-9]+)\}", m => SafeSubstring(RevisionData.CommitHash, int.Parse(m.Groups[1].Value)));
 			format = Regex.Replace(format, @"\{(?:(?:[Xx]|[Bb](?:36)?|d2?)min):.+?\}", FormatTimeScheme);

--- a/NetRevisionTool/VcsProviders/GitProvider.cs
+++ b/NetRevisionTool/VcsProviders/GitProvider.cs
@@ -124,7 +124,32 @@ namespace NetRevisionTool.VcsProviders
 			{
 				p.Kill();
 			}
+            //Try to get tag info for current commit
+            if (string.IsNullOrEmpty(data.Tag))
+            {
+                Program.ShowDebugMessage("Executing: git describe");
+                Program.ShowDebugMessage("  WorkingDirectory: " + path);
+                psi = new ProcessStartInfo(gitExec, "describe");
+                psi.WorkingDirectory = path;
+                psi.RedirectStandardOutput = true;
+                psi.StandardOutputEncoding = Encoding.Default;
+                psi.UseShellExecute = false;
+                p = Process.Start(psi);
+                line = null;
+                while (!p.StandardOutput.EndOfStream)
+                {
+                    line = p.StandardOutput.ReadLine();
+                    Program.ShowDebugMessage(line, 4);
 
+                    if (!string.IsNullOrEmpty(line))
+                        data.Tag = line;
+                }
+                if (!p.WaitForExit(1000))
+                {
+                    p.Kill();
+                }
+                data.IsModified = !string.IsNullOrEmpty(line);
+            }
 			if (!string.IsNullOrEmpty(data.CommitHash))
 			{
 				// Query the working directory state


### PR DESCRIPTION
GIT tag support allows you to tag release revisions and automaticaly use the tag name as a version for your assemblies.
Ex.: If you tag a revision with name 1.1.1 , and perform two commit after this tag, your DLL version should be 1.1.1-2-HASH

That can be accomplished using [assembly: AssemblyInformationalVersion("{gitTag}")]
