### PR TITLE
Suppress the warning about uncommitted changes 

### DIFF
--- a/NetRevisionTool/Program.cs
+++ b/NetRevisionTool/Program.cs
@@ -313,6 +313,9 @@ namespace NetRevisionTool
 		/// <param name="severity">0 (trace message), 1 (success), 2 (warning), 3 (error), 4 (raw output).</param>
 		public static void ShowDebugMessage(string text, int severity = 0)
 		{
+            if (text == null)
+                return;
+
 			if (showDebugOutput)
 			{
 				var color = Console.ForegroundColor;

--- a/NetRevisionTool/VcsProviders/GitProvider.cs
+++ b/NetRevisionTool/VcsProviders/GitProvider.cs
@@ -9,7 +9,10 @@ using Microsoft.Win32;
 
 namespace NetRevisionTool.VcsProviders
 {
-	internal class GitProvider : IVcsProvider
+    /// <summary>
+    /// Git specific.
+    /// </summary>
+    internal class GitProvider : IVcsProvider
 	{
 		#region Private data
 

--- a/NetRevisionTool/VcsProviders/GitProvider.cs
+++ b/NetRevisionTool/VcsProviders/GitProvider.cs
@@ -140,13 +140,20 @@ namespace NetRevisionTool.VcsProviders
 				line = null;
 				while (!p.StandardOutput.EndOfStream)
 				{
-					line = p.StandardOutput.ReadLine();
+                    string templine = p.StandardOutput.ReadLine();
+
+                    // Do not consider this line if it contans any of the file names that can, conceivably appear in the status due to the tool itself.
+
+                    if (!(templine.Contains("AssemblyInfo.cs") || templine.Contains("AssemblyInfo.vb") || templine.Contains("AssemblyInfo.bak")))
+                        line = templine;
+
 					Program.ShowDebugMessage(line, 4);
 				}
 				if (!p.WaitForExit(1000))
 				{
 					p.Kill();
 				}
+
 				data.IsModified = !string.IsNullOrEmpty(line);
 
 				// Query the current branch

--- a/README.md
+++ b/README.md
@@ -28,3 +28,5 @@ By automating the copying of that revision ID into the application source code, 
 ## Licence and terms of use
 
 This software is released under the terms of the GNU GPL licence, version 3. You can find the detailed terms and conditions in the download or on the [GNU website](http://www.gnu.org/licenses/gpl-3.0.html).
+
+This is a work in progress


### PR DESCRIPTION
This PR causes the tool to disregard AssemblyInfo.* files when it detects if there are uncommitted changes.